### PR TITLE
README example - comma missing in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $(function() {
 			if(errorCode && errorMessage) {
 				console.log(errorCode +': '+ errorMessage);
 			}
-		}
+		},
 		success: function() {
 			console.log('The request was successful!');
 		}


### PR DESCRIPTION
A comma is missing between the `error` and success` methods in the README.md example.